### PR TITLE
Feat: introduce getValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ $ yarn add bearray
 - [filter](#filter)
 - [map](#map)
 - [reduce](#reduce)
+- [getValue](#getValue)
 
 ### filter
 > Ƹ̵̡Ӝ̵̨̄Ʒ
@@ -33,7 +34,7 @@ const ᕕ·ᐛ·ᕗ = ʕ·ᴥ·ʔ([1, 2, 3, 4]).Ƹ̵̡Ӝ̵̨̄Ʒ((value, index) 
   return value % 2 === 0;
 });
 
-ᕕ·ᐛ·ᕗ.output // [2, 4]
+ᕕ·ᐛ·ᕗ.ʕᵔᴥᵔʔ() // [2, 4]
 ```
 
 ### map
@@ -48,7 +49,7 @@ const ᕕ·ᐛ·ᕗ = ʕ·ᴥ·ʔ([1, 2, 3, 4]).ʕʘ̅͜ʘ̅ʔ((value, index) =>
   return value + value;
 });
 
-ᕕ·ᐛ·ᕗ.output // [2, 4, 6, 8]
+ᕕ·ᐛ·ᕗ.ʕᵔᴥᵔʔ() // [2, 4, 6, 8]
 ```
 
 ### reduce
@@ -64,5 +65,18 @@ const ᕕ·ᐛ·ᕗ = ʕ·ᴥ·ʔ([1, 2, 3, 4]).ಠ_ಠ((sum, current) => {
 });
 
 
-ᕕ·ᐛ·ᕗ.output // [10]
+ᕕ·ᐛ·ᕗ.ʕᵔᴥᵔʔ() // [10]
+```
+
+### getValue
+> ʕᵔᴥᵔʔ
+
+Get the value at the end of some chained operations (see other functions as well).
+
+```js
+import { ʕ·ᴥ·ʔ } from 'bearray';
+
+const ᕕ·ᐛ·ᕗ = ʕ·ᴥ·ʔ([1, 2, 3, 4]);
+
+ᕕ·ᐛ·ᕗ.ʕᵔᴥᵔʔ() // [1, 2, 3, 4]
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,10 +58,15 @@ const ʕ·ᴥ·ʔ = function (input) {
     return this;
   };
 
+  const ʕᵔᴥᵔʔ = function () {
+    return this.output;
+  };
+
   return {
     ʕʘ̅͜ʘ̅ʔ,
     Ƹ̵̡Ӝ̵̨̄Ʒ,
     ಠ_ಠ,
+    ʕᵔᴥᵔʔ,
   };
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -38,19 +38,19 @@ test('fails on non array in reduce', (t) => {
 test('reduce an array', (t) => {
   const reduce = ʕ·ᴥ·ʔ(arr).ಠ_ಠ((prev, curr) => prev + curr);
 
-  t.deepEqual(reduce.output, [10]);
+  t.deepEqual(reduce.ʕᵔᴥᵔʔ(), [10]);
 });
 
 test('filter all odds of an array', (t) => {
   const filter = ʕ·ᴥ·ʔ(arr).Ƹ̵̡Ӝ̵̨̄Ʒ(value => value % 2 === 0);
 
-  t.deepEqual(filter.output, [2, 4]);
+  t.deepEqual(filter.ʕᵔᴥᵔʔ(), [2, 4]);
 });
 
 test('multiply all elements by 2', (t) => {
   const map = ʕ·ᴥ·ʔ(arr).ʕʘ̅͜ʘ̅ʔ(value => value * value);
 
-  t.deepEqual(map.output, [1, 4, 9, 16]);
+  t.deepEqual(map.ʕᵔᴥᵔʔ(), [1, 4, 9, 16]);
 });
 
 test('chain some methods', (t) => {
@@ -58,7 +58,7 @@ test('chain some methods', (t) => {
     .Ƹ̵̡Ӝ̵̨̄Ʒ(value => value % 2 === 0)
     .ಠ_ಠ((prev, curr) => prev + curr);
 
-  t.deepEqual(map.output, [6]);
+  t.deepEqual(map.ʕᵔᴥᵔʔ(), [6]);
 });
 
 test('🥚', (t) => {


### PR DESCRIPTION
It is a bad practice to call `output` directly. It is better to return it by a function. It would be `getValue` but in our case it is a wonderful happy bear `ʕᵔᴥᵔʔ`